### PR TITLE
rocblas.h has moved in rocm >=6

### DIFF
--- a/src/gpu_util/gpu_blas_api.hpp
+++ b/src/gpu_util/gpu_blas_api.hpp
@@ -38,7 +38,7 @@
 #include <cublas_v2.h>
 
 #elif defined(SPLA_ROCM)
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 
 #else
 #error Either SPLA_CUDA or SPLA_ROCM must be defined!


### PR DESCRIPTION
`#include<rocblas.h>` has been deprecated since rocm `5.x` and is an error since `6.0.0`. 